### PR TITLE
Update Developer ID Installer

### DIFF
--- a/AppGate SDP/AppGate SDP.download.recipe
+++ b/AppGate SDP/AppGate SDP.download.recipe
@@ -39,7 +39,7 @@
 			<dict>
 				<key>expected_authority_names</key>
 				<array>
-					<string>Developer ID Installer: CYXTERA TECHNOLOGIES, INC. (786P3GHDF5)</string>
+					<string>Developer ID Installer: Appgate Cybersecurity, Inc (HYXN7HQ378)</string>
 					<string>Developer ID Certification Authority</string>
 					<string>Apple Root CA</string>
 				</array>


### PR DESCRIPTION
Modified expected Developer ID to reflect the correct authority name.

See below `autopkg` logs:

> CodeSignatureVerifier: Package "Appgate SDP Installer.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2023-10-24 08:43:16 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Appgate Cybersecurity, Inc (HYXN7HQ378)
CodeSignatureVerifier:        Expires: 2027-01-26 12:09:41 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            46 8A BE 4F 06 0D 87 CD 6E EB 8D 15 CC DE 97 4A 8D E1 4F E5 0A CF 
CodeSignatureVerifier:            6F 5B 0B D6 95 97 D5 10 9C B9
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03 
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Mismatch in authority names
CodeSignatureVerifier: Expected: Developer ID Installer: CYXTERA TECHNOLOGIES, INC. (786P3GHDF5) -> Developer ID Certification Authority -> Apple Root CA
CodeSignatureVerifier: Found:    Developer ID Installer: Appgate Cybersecurity, Inc (HYXN7HQ378) -> Developer ID Certification Authority -> Apple Root CA
Mismatch in authority names. Note that all verification can be disabled by setting the variable DISABLE_CODE_SIGNATURE_VERIFICATION to a non-empty value.