### PR TITLE
Deprecate arm64-specific Postman recipe

### DIFF
--- a/Postman-arm64/Postman-arm64.download.recipe
+++ b/Postman-arm64/Postman-arm64.download.recipe
@@ -18,6 +18,15 @@
     <key>Process</key>
     <array>
         <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>The Postman recipes in the bnpl-recipes repo already support multiple architectures via the DOWNLOAD_URL input variable. These arm64-specific recipes are deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
+        <dict>
             <key>Arguments</key>
             <dict>
                 <key>url</key>


### PR DESCRIPTION
The [Postman.download recipe in bnpl-recipes](https://github.com/autopkg/bnpl-recipes/blob/master/Postman/Postman.download.recipe) already supports Apple Silicon downloads via the `DOWNLOAD_URL` input variable. I've submitted https://github.com/autopkg/bnpl-recipes/pull/77 in order to clarify that capability, but in the meantime these arm64-specific Postman recipes are redundant. I've marked them as deprecated with a pointer to bnpl-recipes for anybody still using them.