### PR TITLE
Deprecate arm64-specific Spotify recipe

### DIFF
--- a/Spotify-arm64/Spotify-arm64.download.recipe
+++ b/Spotify-arm64/Spotify-arm64.download.recipe
@@ -19,6 +19,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>The Spotify recipes in the autopkg/recipes repository support multiple architectures via the DOWNLOAD_ARCH and SUPPORTED_ARCH input variables. This arm64-specific Spotify recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>URLDownloader</string>
             <key>Arguments</key>
             <dict>


### PR DESCRIPTION
The [Spotify.download recipe in autopkg/recipes](https://github.com/autopkg/recipes/blob/master/Spotify/Spotify.download.recipe) already supports Apple Silicon downloads via the DOWNLOAD_ARCH and SUPPORTED_ARCH input variables, so these arm64-specific Spotify recipes are redundant. I've marked them as deprecated with a pointer to autopkg/recipes for anybody still using them.